### PR TITLE
43 reorganise api paths

### DIFF
--- a/.cursor/rules/code-review.mdc
+++ b/.cursor/rules/code-review.mdc
@@ -1,5 +1,5 @@
 ---
-description: When a developer asks you to review code.
+description: Review code
 globs: 
 alwaysApply: false
 ---

--- a/.cursor/rules/example-data.mdc
+++ b/.cursor/rules/example-data.mdc
@@ -1,5 +1,5 @@
 ---
-description: 
+description: Data fetching pattern; database, server components, api endpoints, hooks and client components
 globs: 
 alwaysApply: false
 ---

--- a/.cursor/rules/example-link.mdc
+++ b/.cursor/rules/example-link.mdc
@@ -1,5 +1,5 @@
 ---
-description: 
+description: Next.js links
 globs: 
 alwaysApply: false
 ---

--- a/.cursor/rules/log.mdc
+++ b/.cursor/rules/log.mdc
@@ -1,5 +1,5 @@
 ---
-description: When the user asks you to log changes
+description: Log changes
 globs: 
 alwaysApply: false
 ---

--- a/.cursor/rules/patterns.mdc
+++ b/.cursor/rules/patterns.mdc
@@ -14,6 +14,7 @@ alwaysApply: true
 
 ## Type Safety
 - Always specify the return type.
+- Types always start with a capital letter
 - Model type naming: 
    - `[model]` e.g. `Tile` shape of data with the most common fields needed for the presentation layer. Usually constructured from several table joins. Must only be used server-side
    - `[model]Safe` e.g. `TileSafe` shape of data with only the fields that are safe to send to the client.

--- a/.cursor/rules/pr-helper.mdc
+++ b/.cursor/rules/pr-helper.mdc
@@ -1,5 +1,5 @@
 ---
-description: When a developer asks you to write a PR.
+description: Write a PR (pull request)
 globs: 
 alwaysApply: false
 ---
@@ -8,7 +8,7 @@ alwaysApply: false
 - Review the latest version of the pull request template [pull_request_template.md](mdc:docs/pull_request_template.md)
 - Review the gif diff against the main branch
 
-- Ask the user to run `pmpm lint`
+- Ask the user to run `pmpm lint` in the terminal. Wait for this to complete so you can see the current lint errors
 - Ask the user if they would like to update documentation in `/docs`. If yes read that folder and look for anything that needs to be updated.
 
 - Draft the description section for this pull request

--- a/.cursor/rules/pr-helper.mdc
+++ b/.cursor/rules/pr-helper.mdc
@@ -12,7 +12,7 @@ alwaysApply: false
 - Ask the user if they would like to update documentation in `/docs`. If yes read that folder and look for anything that needs to be updated.
 
 - Draft the description section for this pull request
-- Be concise. If the change is small the description can be small.
+- Be concise. If the change is small, the description can be small.
 - Use markdown formatting in a codeblock
 - If no unit tests have been added or changed, do not write anything under the testing section.
 - Do not fill out the checklist.

--- a/app/api/suppliers/[id]/tiles/route.ts
+++ b/app/api/suppliers/[id]/tiles/route.ts
@@ -14,8 +14,8 @@ export type TilesGetRequestParams = z.infer<typeof tilesGetRequestParams>
 
 export type TilesGetResponseBody = t.Tile[]
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
-  const supplierId = params.id
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }): Promise<NextResponse> {
+  const supplierId = (await params).id
   const { userId } = parseQueryParams(req.nextUrl, tilesGetRequestParams)
 
   // Only check authentication if a userId is provided

--- a/app/api/suppliers/[id]/tiles/route.ts
+++ b/app/api/suppliers/[id]/tiles/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse, NextRequest } from 'next/server'
+import { TileModel } from '@/models/tile'
+import { parseQueryParams } from '@/utils/api-helpers'
+import { z } from 'zod'
+import * as t from '@/models/types'
+import { getAuthenticatedUserId } from '@/utils/auth'
+import { tryCatch } from '@/utils/try-catch'
+
+const tilesGetRequestParams = z.object({
+  userId: z.string().optional(),
+})
+
+export type TilesGetRequestParams = z.infer<typeof tilesGetRequestParams>
+
+export type TilesGetResponseBody = t.Tile[]
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  const supplierId = params.id
+  const { userId } = parseQueryParams(req.nextUrl, tilesGetRequestParams)
+
+  // Only check authentication if a userId is provided
+  if (userId) {
+    const authUserId = await getAuthenticatedUserId()
+    if (!authUserId || authUserId !== userId) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+    }
+  }
+
+  const { data, error } = await tryCatch(TileModel.getBySupplierId(supplierId, userId))
+
+  if (error) {
+    return NextResponse.json({ message: 'Error fetching tiles', error: error.message }, { status: 500 })
+  }
+
+  const tiles: TilesGetResponseBody = data
+
+  return NextResponse.json(tiles)
+}

--- a/app/api/tiles/route.ts
+++ b/app/api/tiles/route.ts
@@ -1,46 +1,7 @@
-import { NextResponse, NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
 import { TileModel } from '@/models/tile'
-import { parseQueryParams } from '@/utils/api-helpers'
-import { z } from 'zod'
 import * as t from '@/models/types'
 import { getAuthenticatedUserId } from '@/utils/auth'
-
-import { tryCatch } from '@/utils/try-catch'
-
-const tilesGetRequestParams = z.object({
-  supplierId: z.string(),
-  userId: z.string().optional(),
-})
-
-export type TilesGetRequestParams = z.infer<typeof tilesGetRequestParams>
-
-export type TilesGetResponseBody = t.Tile[]
-
-export async function GET(req: NextRequest): Promise<NextResponse> {
-  const { supplierId, userId } = parseQueryParams(req.nextUrl, tilesGetRequestParams)
-
-  if (!supplierId) {
-    return NextResponse.json({ message: 'Missing supplierId' }, { status: 400 })
-  }
-
-  // Only check authentication if a userId is provided
-  if (userId) {
-    const authUserId = await getAuthenticatedUserId()
-    if (!authUserId || authUserId !== userId) {
-      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
-    }
-  }
-
-  const { data, error } = await tryCatch(TileModel.getBySupplierId(supplierId, userId))
-
-  if (error) {
-    return NextResponse.json({ message: 'Error fetching tiles', error: error.message }, { status: 500 })
-  }
-
-  const tiles: TilesGetResponseBody = data
-
-  return NextResponse.json(tiles)
-}
 
 export interface tileNewRequestBody extends t.InsertTileRaw {
   suppliers: t.SupplierRaw[]
@@ -48,6 +9,7 @@ export interface tileNewRequestBody extends t.InsertTileRaw {
 
 export type tileNewResponseBody = t.TileRawWithSuppliers
 
+// Create a new tile
 export async function POST(req: Request): Promise<NextResponse> {
   const body = (await req.json()) as tileNewRequestBody
   const authUserId = await getAuthenticatedUserId()
@@ -60,24 +22,4 @@ export async function POST(req: Request): Promise<NextResponse> {
   const tile: tileNewResponseBody = await TileModel.createRawWithSuppliers(rest, suppliers)
 
   return NextResponse.json(tile)
-}
-
-export interface tilesUpdateRequestBody {
-  tiles: t.TileRaw[]
-}
-
-export interface tilesUpdateResponseBody {
-  tileIds: string[]
-}
-
-export async function PUT(req: Request): Promise<NextResponse> {
-  const body = (await req.json()) as tilesUpdateRequestBody
-  const authUserId = await getAuthenticatedUserId()
-  if (!authUserId) {
-    return new NextResponse('Unauthorized', { status: 401 })
-  }
-
-  const tiles = await TileModel.updateAllRaw(body.tiles)
-
-  return NextResponse.json({ tileIds: tiles.map((tile) => tile.id) } as tilesUpdateResponseBody)
 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react'
 import { ThemeProvider } from 'next-themes'
 import { isServer, QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 
 function makeQueryClient() {
   return new QueryClient({
@@ -44,6 +45,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
         {children}
       </ThemeProvider>
+      <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   )
 }

--- a/app/suppliers/[handle]/new/upload-preview-form.tsx
+++ b/app/suppliers/[handle]/new/upload-preview-form.tsx
@@ -45,6 +45,7 @@ export function UploadPreviewForm({
       {status === 'idle' ? (
         <div className="grid grid-cols-[1fr_3fr] gap-6">
           <div className="aspect-square overflow-hidden bg-muted rounded-lg">
+            {/* eslint-disable-next-line @next/next/no-img-element -- This is a client-side preview of a local file, so Next.js Image optimization isn't needed */}
             <img src={file.fileObjectUrl} alt={file.file.name} className="object-contain w-full h-full" />
           </div>
 

--- a/hooks/use-supplier-tiles.ts
+++ b/hooks/use-supplier-tiles.ts
@@ -1,8 +1,9 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
-import { TilesGetRequestParams, TilesGetResponseBody } from '@/app/api/tiles/route'
+import { TilesGetRequestParams, TilesGetResponseBody } from '@/app/api/suppliers/[id]/tiles/route'
 import { buildQueryParams } from '@/utils/api-helpers'
+import { tryCatch } from '@/utils/try-catch'
 
 export function useSupplierTiles(supplierId: string, userId?: string) {
   return useQuery({
@@ -12,22 +13,19 @@ export function useSupplierTiles(supplierId: string, userId?: string) {
 }
 
 async function fetchTilesForSupplier(supplierId: string, userId?: string) {
-  const getTilesParams: TilesGetRequestParams = { supplierId, userId }
+  const getTilesParams: TilesGetRequestParams = { userId }
   const queryParams = buildQueryParams(getTilesParams)
-  const res = await fetch(`/api/tiles${queryParams}`)
+  const res = await fetch(`/api/suppliers/${supplierId}/tiles${queryParams}`)
 
   if (!res.ok) {
-    // Try to parse the error response as JSON first
-    try {
-      const errorData = await res.json()
-      throw new Error(errorData.message || `Failed to fetch tiles: ${res.statusText}`)
-    } catch (e) {
-      // If we can't parse as JSON, it might be an auth redirect
-      if (res.status === 401 || res.status === 403) {
-        throw new Error('Please sign in to view tiles')
-      }
-      throw new Error(`Failed to fetch tiles: ${res.statusText}`)
+    const { data: errorData, error } = await tryCatch(res.json())
+
+    // If we can't parse as JSON, it might be an auth redirect
+    if (error && (res.status === 401 || res.status === 403)) {
+      throw new Error('Please sign in to view tiles')
     }
+
+    throw new Error(errorData?.message || `Failed to fetch tiles: ${res.statusText}`)
   }
 
   const tiles: TilesGetResponseBody = await res.json()

--- a/models/tile.ts
+++ b/models/tile.ts
@@ -46,20 +46,7 @@ export class TileModel {
 
     // Get the user's saved status for each tile
     if (userId) {
-      const { data: savedTiles, error } = await tryCatch(
-        db
-          .select()
-          .from(s.savedTiles)
-          .where(
-            and(
-              eq(s.savedTiles.userId, userId),
-              inArray(
-                s.savedTiles.tileId,
-                tiles.map((t) => t.id)
-              )
-            )
-          )
-      )
+      const { data: savedTiles, error } = await tryCatch(getSavedTilesRaw(tiles, userId))
 
       if (error) {
         throw new Error('database error')
@@ -216,6 +203,22 @@ function aggregateTileQueryResults(result: TileBaseQueryResult[]): t.TileRawWith
   }
 
   return Array.from(tileMap.values())
+}
+
+async function getSavedTilesRaw(tiles: t.TileRaw[] | t.Tile[], userId: string): Promise<t.SavedTileRaw[]> {
+  const savedTiles = await db
+    .select()
+    .from(s.savedTiles)
+    .where(
+      and(
+        eq(s.savedTiles.userId, userId),
+        inArray(
+          s.savedTiles.tileId,
+          tiles.map((t) => t.id)
+        )
+      )
+    )
+  return savedTiles
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@supabase/ssr": "latest",
     "@supabase/supabase-js": "latest",
     "@tanstack/react-query": "^5.71.1",
+    "@tanstack/react-query-devtools": "^5.71.5",
     "@uploadthing/react": "^7.3.0",
     "autoprefixer": "10.4.20",
     "class-variance-authority": "^0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.71.1
         version: 5.71.1(react@19.0.0)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.71.5
+        version: 5.71.5(@tanstack/react-query@5.71.1(react@19.0.0))(react@19.0.0)
       '@uploadthing/react':
         specifier: ^7.3.0
         version: 7.3.0(next@15.1.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(uploadthing@7.5.2(next@15.1.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(tailwindcss@3.4.17))
@@ -1459,6 +1462,15 @@ packages:
 
   '@tanstack/query-core@5.71.1':
     resolution: {integrity: sha512-4+ZswCHOfJX+ikhXNoocamTUmJcHtB+Ljjz/oJkC7/eKB5IrzEwR4vEwZUENiPi+wISucJHR5TUbuuJ26w3kdQ==}
+
+  '@tanstack/query-devtools@5.71.5':
+    resolution: {integrity: sha512-Fq1JeAp+I52Md/KnyeFxzG7G0RpdHgeOfDNhSPkZQs/JqqXuAfpUf+wFHDz+vP0GZbSnla2JmcLSQebOkIb1yA==}
+
+  '@tanstack/react-query-devtools@5.71.5':
+    resolution: {integrity: sha512-VErQ29hgwmLrZjMmHp83iv+UdeCbqAyj/JR1mZjDbf+ghyJT+Hmh8jfbh6WYzKh8Fnej7uwl3nHbCsqd3VjoWw==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.71.5
+      react: ^18 || ^19
 
   '@tanstack/react-query@5.71.1':
     resolution: {integrity: sha512-6BTkaSIGT58MroI4kIGXNdx/NhirXPU+75AJObLq+WBa39WmoxhzSk0YX+hqWJ/bvqZJFxslbEU4qIHaRZq+8Q==}
@@ -4347,6 +4359,14 @@ snapshots:
       tslib: 2.8.1
 
   '@tanstack/query-core@5.71.1': {}
+
+  '@tanstack/query-devtools@5.71.5': {}
+
+  '@tanstack/react-query-devtools@5.71.5(@tanstack/react-query@5.71.1(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@tanstack/query-devtools': 5.71.5
+      '@tanstack/react-query': 5.71.1(react@19.0.0)
+      react: 19.0.0
 
   '@tanstack/react-query@5.71.1(react@19.0.0)':
     dependencies:


### PR DESCRIPTION
## Description
<!-- Provide a brief context and concise description of the changes made in this PR
Explain **what** this PR does and **why** it is needed.
Consider the audiences; reviewers, future developers, product managers, etc. 
-->

This PR reorganizes the API paths and improves error handling for tile-related endpoints. It also adds React Query DevTools for better debugging capabilities.

- Reorganized API paths:
  - Moved tile fetching endpoint from `/api/tiles` to `/api/suppliers/[id]/tiles` for better REST organization
  - Simplified `/api/tiles` route to only handle POST requests for creating new tiles
  - Removed unused PUT endpoint from `/api/tiles`

- Other changes:
  - Refactored error handling in `useSupplierTiles` hook to use `tryCatch` utility
  - Extracted `getSavedTilesRaw` into a separate function for better reusability
  - Installed `@tanstack/react-query-devtools`



## Testing
<!-- Describe unit tests added (if any) and testing performed -->


## Checklist
<!-- Mark completed items with 'x' -->
- [ ] Code has been linted/formatted
- [ ] Database migrations have been run
- [ ] Documentation has been updated (if applicable)
- [ ] Tests have been added/updated (if applicable)
- [ ] All tests are passing


## Additional Context
<!-- Link related PR's and tickets -->
<!-- Add any additional information that reviewers should know -->