### PR TITLE
Hemi/wr 56 setup image placeholders

### DIFF
--- a/app/account/loading.tsx
+++ b/app/account/loading.tsx
@@ -1,5 +1,9 @@
 import { MasonryLoader } from '@/components/loader'
 
 export default function Loading() {
-  return <MasonryLoader />
+  return (
+    <div className="row-span-full">
+      <MasonryLoader />
+    </div>
+  )
 }

--- a/app/locations/[location]/page.tsx
+++ b/app/locations/[location]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation'
 
-import { SuppliersList } from '@/components/suppliers/suppliers-list'
+import { SuppliersGrid, SupplierCard } from '@/components/suppliers/suppliers-list'
 import { Area } from '@/components/ui/area'
 import { Section } from '@/components/ui/section'
 import { Location } from '@/db/constants'
@@ -24,7 +24,22 @@ export default async function LocationPage({ params }: { params: Promise<{ locat
           <div className="flex flex-col gap-xs">
             <h1 className="font-serif text-4xl">{valueToPretty(location)}</h1>
           </div>
-          <SuppliersList suppliers={suppliers} />
+          <SuppliersGrid>
+            {suppliers.map((supplier) => (
+              <SupplierCard
+                key={supplier.id}
+                href={`/suppliers/${supplier.handle}`}
+                mainImage={'https://images.unsplash.com/photo-1606216794074-735e91aa2c92'}
+                thumbnailImages={[
+                  'https://images.unsplash.com/photo-1649615644622-6d83f48e69c5',
+                  'https://images.unsplash.com/photo-1665607437981-973dcd6a22bb',
+                ]}
+                name={supplier.name}
+                subtitle={supplier.locations.map((location) => valueToPretty(location)).join(', ')}
+                stat={150}
+              />
+            ))}
+          </SuppliersGrid>
         </div>
       </Area>
     </Section>

--- a/app/locations/[location]/page.tsx
+++ b/app/locations/[location]/page.tsx
@@ -35,7 +35,7 @@ export default async function LocationPage({ params }: { params: Promise<{ locat
                   'https://images.unsplash.com/photo-1665607437981-973dcd6a22bb',
                 ]}
                 name={supplier.name}
-                subtitle={supplier.locations.map((location) => valueToPretty(location)).join(', ')}
+                subtitle={supplier.services.map((service) => valueToPretty(service)).join(', ')}
                 stat={150}
               />
             ))}

--- a/app/services/[service]/page.tsx
+++ b/app/services/[service]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation'
 
-import { SuppliersList } from '@/components/suppliers/suppliers-list'
+import { SuppliersGrid, SupplierCard } from '@/components/suppliers/suppliers-list'
 import { Area } from '@/components/ui/area'
 import { Section } from '@/components/ui/section'
 import { Service } from '@/db/constants'
@@ -24,7 +24,22 @@ export default async function ServicePage({ params }: { params: Promise<{ servic
           <div className="flex flex-col gap-xs">
             <h1 className="font-serif text-4xl">{valueToPretty(service)}</h1>
           </div>
-          <SuppliersList suppliers={suppliers} />
+          <SuppliersGrid>
+            {suppliers.map((supplier) => (
+              <SupplierCard
+                key={supplier.id}
+                href={`/suppliers/${supplier.handle}`}
+                mainImage={'https://images.unsplash.com/photo-1606216794074-735e91aa2c92'}
+                thumbnailImages={[
+                  'https://images.unsplash.com/photo-1649615644622-6d83f48e69c5',
+                  'https://images.unsplash.com/photo-1665607437981-973dcd6a22bb',
+                ]}
+                name={supplier.name}
+                subtitle={supplier.locations.map((location) => valueToPretty(location)).join(', ')}
+                stat={150}
+              />
+            ))}
+          </SuppliersGrid>
         </div>
       </Area>
     </Section>

--- a/app/suppliers/page.tsx
+++ b/app/suppliers/page.tsx
@@ -1,7 +1,7 @@
-import { SuppliersList } from '@/components/suppliers/suppliers-list'
+import { SupplierCard, SuppliersGrid } from '@/components/suppliers/suppliers-list'
 import { Section } from '@/components/ui/section'
 import { SupplierModel } from '@/models/supplier'
-
+import { valueToPretty } from '@/utils/enum-helpers'
 
 export default async function SuppliersPage() {
   const suppliers = await SupplierModel.getAll()
@@ -9,7 +9,20 @@ export default async function SuppliersPage() {
   return (
     <Section>
       <h1 className="text-2xl font-bold">Suppliers</h1>
-      <SuppliersList suppliers={suppliers} />
+
+      <SuppliersGrid>
+        {suppliers.map((supplier) => (
+          <SupplierCard
+            key={supplier.id}
+            href={`/suppliers/${supplier.handle}`}
+            mainImage={'https://images.unsplash.com/photo-1606216794074-735e91aa2c92'}
+            thumbnailImages={['https://images.unsplash.com/photo-1649615644622-6d83f48e69c5', 'https://images.unsplash.com/photo-1665607437981-973dcd6a22bb']}
+            name={supplier.name}
+            subtitle={supplier.locations.map((location) => valueToPretty(location)).join(', ')}
+            stat={150}
+          />
+        ))}
+      </SuppliersGrid>
     </Section>
   )
 }

--- a/components/suppliers/suppliers-list.tsx
+++ b/components/suppliers/suppliers-list.tsx
@@ -1,7 +1,7 @@
-import Link from 'next/link'
 
 import { Star } from 'lucide-react'
 import Image from 'next/image'
+import Link from 'next/link'
 
 export function SuppliersGrid({ children }: { children: React.ReactNode }) {
   return <div className="grid grid-cols-1 gap-lg md:grid-cols-2 lg:grid-cols-3">{children}</div>

--- a/components/suppliers/suppliers-list.tsx
+++ b/components/suppliers/suppliers-list.tsx
@@ -1,26 +1,10 @@
 import Link from 'next/link'
 
-import { Supplier } from '@/models/types'
-import { valueToPretty } from '@/utils/enum-helpers'
 import { Star } from 'lucide-react'
 import Image from 'next/image'
 
-export function SuppliersList({ suppliers }: { suppliers: Supplier[] }) {
-  return (
-    <div className="grid grid-cols-1 gap-lg md:grid-cols-2 lg:grid-cols-3">
-      {suppliers.map((supplier) => (
-        <SupplierCard
-          key={supplier.id}
-          href={`/suppliers/${supplier.handle}`}
-          mainImage={'https://images.unsplash.com/photo-1606216794074-735e91aa2c92'}
-          thumbnailImages={['https://images.unsplash.com/photo-1649615644622-6d83f48e69c5', 'https://images.unsplash.com/photo-1665607437981-973dcd6a22bb']}
-          name={supplier.name}
-          subtitle={supplier.locations.map((location) => valueToPretty(location)).join(', ')}
-          stat={150}
-        />
-      ))}
-    </div>
-  )
+export function SuppliersGrid({ children }: { children: React.ReactNode }) {
+  return <div className="grid grid-cols-1 gap-lg md:grid-cols-2 lg:grid-cols-3">{children}</div>
 }
 
 type SupplierCardProps = {

--- a/components/suppliers/suppliers-list.tsx
+++ b/components/suppliers/suppliers-list.tsx
@@ -1,30 +1,65 @@
 import Link from 'next/link'
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Supplier } from '@/models/types'
+import { valueToPretty } from '@/utils/enum-helpers'
+import { Star } from 'lucide-react'
+import Image from 'next/image'
 
 export function SuppliersList({ suppliers }: { suppliers: Supplier[] }) {
   return (
-    <div className="grid grid-cols-1 gap-md md:grid-cols-2 lg:grid-cols-3">
+    <div className="grid grid-cols-1 gap-lg md:grid-cols-2 lg:grid-cols-3">
       {suppliers.map((supplier) => (
-        <SupplierCard key={supplier.id} supplier={supplier} />
+        <SupplierCard
+          key={supplier.id}
+          href={`/suppliers/${supplier.handle}`}
+          mainImage={'https://images.unsplash.com/photo-1606216794074-735e91aa2c92'}
+          thumbnailImages={['https://images.unsplash.com/photo-1649615644622-6d83f48e69c5', 'https://images.unsplash.com/photo-1665607437981-973dcd6a22bb']}
+          name={supplier.name}
+          subtitle={supplier.locations.map((location) => valueToPretty(location)).join(', ')}
+          stat={150}
+        />
       ))}
     </div>
   )
 }
 
-export function SupplierCard({ supplier }: { supplier: Supplier }) {
+type SupplierCardProps = {
+  href: string
+  mainImage: string
+  thumbnailImages: string[]
+  name: string
+  subtitle: string
+  stat: number
+  avatar?: string
+}
+
+export function SupplierCard({ name, subtitle, mainImage, thumbnailImages, stat, href, avatar }: SupplierCardProps) {
   return (
-    <Link href={`/suppliers/${supplier.handle}`} passHref>
-      <Card>
-        <CardHeader>
-          <CardTitle>{supplier.name}</CardTitle>
-          <CardDescription>{supplier.description}</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground">View supplier</p>
-        </CardContent>
-      </Card>
+    <Link href={href} className="grid gap-xs transition-colors hover:bg-accent/80 focus:bg-accent/80">
+      <div className="grid max-w-full grid-cols-3 grid-rows-2 gap-[1px] overflow-hidden rounded-md">
+        <div className="relative col-span-2 row-span-2 aspect-square bg-white">
+          <Image src={mainImage} alt={name} fill sizes="100vw" className="object-cover" />
+        </div>
+        <div className="relative aspect-square bg-white">
+          <Image src={thumbnailImages[0]} alt={name} fill sizes="50vw" className="object-cover" />
+        </div>
+        <div className="relative aspect-square bg-white">
+          <Image src={thumbnailImages[1]} alt={name} fill sizes="50vw" className="object-cover" />
+        </div>
+      </div>
+      <div className="grid grid-cols-[1fr_auto] gap-xs px-xs">
+        <div className="flex gap-xs">
+          {avatar && <Image src={avatar} alt={name} className="h-[32px] w-[32px] rounded-full bg-white" />}
+          <div>
+            <h2 className="text-sm font-medium">{name}</h2>
+            <p className="text-sm text-muted-foreground">{subtitle}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-xxs self-start text-sm text-muted-foreground">
+          <Star size={16} />
+          <p>1.5k</p>
+        </div>
+      </div>
     </Link>
   )
 }

--- a/components/suppliers/suppliers-list.tsx
+++ b/components/suppliers/suppliers-list.tsx
@@ -32,11 +32,11 @@ export function SupplierCard({ name, subtitle, mainImage, thumbnailImages, stat,
         </div>
       </div>
       <div className="grid grid-cols-[1fr_auto] gap-xs px-xs">
-        <div className="flex gap-xs">
+        <div className="flex max-w-[200px] gap-xs">
           {avatar && <Image src={avatar} alt={name} className="h-[32px] w-[32px] rounded-full bg-white" />}
-          <div>
-            <h2 className="text-sm font-medium">{name}</h2>
-            <p className="text-sm text-muted-foreground">{subtitle}</p>
+          <div className="w-full text-sm">
+            <h2 className="truncate font-medium">{name}</h2>
+            <p className="truncate text-muted-foreground">{subtitle}</p>
           </div>
         </div>
         <div className="flex items-center gap-xxs self-start text-sm text-muted-foreground">

--- a/components/suppliers/suppliers-list.tsx
+++ b/components/suppliers/suppliers-list.tsx
@@ -41,7 +41,7 @@ export function SupplierCard({ name, subtitle, mainImage, thumbnailImages, stat,
         </div>
         <div className="flex items-center gap-xxs self-start text-sm text-muted-foreground">
           <Star size={16} />
-          <p>1.5k</p>
+          <p>{stat}</p>
         </div>
       </div>
     </Link>

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,10 @@ const nextConfig: NextConfig = {
         hostname: 'jjoptcpwkl.ufs.sh',
         pathname: '/f/*',
       },
+      {
+        protocol: 'https',
+        hostname: 'images.unsplash.com',
+      },
     ],
   },
   /* config options here */


### PR DESCRIPTION
## Description

<!-- Provide a brief context and concise description of the changes made in this PR
Explain **what** this PR does and **why** it is needed.
Consider the audiences; reviewers, future developers, product managers, etc.
-->
This PR refactors the supplier listing UI across the app to introduce new image placeholders and a modern card-based grid layout for suppliers. Key changes include:

- Replaces the old `SuppliersList` with a new `SuppliersGrid` and `SupplierCard` component, featuring image placeholders and improved visual hierarchy.
- Updates supplier pages (`/suppliers`, `/locations/[location]`, `/services/[service]`) to use the new grid and card components, displaying main and thumbnail images for each supplier.
- Adds Unsplash as an allowed image domain in `next.config.ts` for placeholder images.

These changes improve the visual presentation of suppliers and set up the structure for future dynamic image integration.

## Testing

<!-- Describe unit tests added (if any) and testing performed -->

## Checklist

<!-- Mark completed items with 'x' -->

- [x] Code has been linted/formatted
- [x] Database migrations have been run
- [x] Documentation has been updated (if applicable)
- [ ] Tests have been added/updated (if applicable)
- [ ] All tests are passing

## Additional Context

<!-- Link related PR's and tickets -->
<!-- Add any additional information that reviewers should know -->
