### PR TITLE
Use semanatic names for breakpoints

### DIFF
--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -40,6 +40,6 @@
 
 ### Responsive Design
 
-- Use mobile-first approach with Tailwind's responsive prefixes (sm:, md:, lg:). Default styles apply to mobile first, and override as needed for larger break points
+- Use mobile-first approach with Tailwind's responsive prefixes (tablet:, laptop:, wide:). Default styles apply to mobile first, and override as needed for larger break points
 - Follow consistent spacing using our design tokens (gap-area, gap-sibling, etc.)
 - Use CSS Grid for complex layouts with responsive breakpoints

--- a/src/app/account/layout.tsx
+++ b/src/app/account/layout.tsx
@@ -8,14 +8,13 @@ import { Area } from '@/components/ui/area'
 import { Section } from '@/components/ui/section'
 import { cn } from '@/utils/shadcn-utils'
 
-
 export default function AccountLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
 
   return (
     <Section className="min-h-svh-minus-header pt-0">
-      <div className="grid grid-cols-1 gap-area md:grid-cols-[minmax(200px,1fr)_3fr]">
-        <nav className="grid auto-rows-fr gap-sibling self-start md:pt-10">
+      <div className="laptop:grid-cols-[minmax(200px,1fr)_3fr] grid grid-cols-1 gap-area">
+        <nav className="laptop:pt-10 grid auto-rows-fr gap-sibling self-start">
           <AccountNavLink
             href="/account"
             currentPathname={pathname}

--- a/src/app/find-suppliers/page.tsx
+++ b/src/app/find-suppliers/page.tsx
@@ -10,7 +10,6 @@ import { enumKeyToParam, enumToPretty } from '@/utils/enum-helpers'
 
 import { tags } from '../_types/tags'
 
-
 const locationTags = enumToPretty(Location).map((location) => tags.locationSuppliers(location.key))
 const getCachedLocations = unstable_cache(locationOperations.getAllWithSupplierCount, locationTags)
 
@@ -30,7 +29,7 @@ export default async function FindSuppliers() {
           <Area>
             <div className="grid gap-friend">
               <h2 className="ui-s1">Explore suppliers by location</h2>
-              <ul className="columns-2 gap-acquaintance md:columns-3">
+              <ul className="laptop:columns-3 columns-2 gap-acquaintance">
                 {locations.map((location) => (
                   <li key={location.key} className="py-xs">
                     <FindSuppliersItem label={location.value} href={`/locations/${enumKeyToParam(location.key)}`} supplierCount={location.supplierCount} />
@@ -42,7 +41,7 @@ export default async function FindSuppliers() {
           <Area>
             <div className="grid gap-friend">
               <h2 className="ui-s1">Explore suppliers by service category</h2>
-              <ul className="columns-2 gap-acquaintance md:columns-3">
+              <ul className="laptop:columns-3 columns-2 gap-acquaintance">
                 {services.map((service) => (
                   <li key={service.key} className="py-xs">
                     <FindSuppliersItem label={service.value} href={`/services/${enumKeyToParam(service.key)}`} supplierCount={service.supplierCount} />
@@ -73,8 +72,8 @@ function FindSuppliersItem({ label, href, supplierCount }: FindSuppliersItemProp
   const formattedSupplierCount = formatSupplierCount(supplierCount)
 
   return (
-    <Link href={href} className="grid items-start gap-x-partner sm:grid-cols-[auto_1fr]">
-      <h3 className="row-start-2 text-lg sm:row-start-1">{label}</h3>
+    <Link href={href} className="tablet:grid-cols-[auto_1fr] grid items-start gap-x-partner">
+      <h3 className="tablet:row-start-1 row-start-2 text-lg">{label}</h3>
       <span className="ui-small row-start-1 text-muted-foreground">{formattedSupplierCount}</span>
     </Link>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,13 +47,13 @@ export default function Home() {
   return (
     <>
       <Section className="min-h-svh-minus-header pt-0">
-        <div className="grid grid-cols-3 gap-area md:grid-rows-4">
-          <Area className="col-span-full grid place-content-center gap-acquaintance md:col-span-2 md:row-span-full">
-            <div className="flex flex-col gap-sibling md:pr-xxl">
+        <div className="laptop:grid-rows-4 grid grid-cols-3 gap-area">
+          <Area className="laptop:col-span-2 laptop:row-span-full col-span-full grid place-content-center gap-acquaintance">
+            <div className="laptop:pr-xxl flex flex-col gap-sibling">
               <h1 className="heading-2xl">Wedding inspiration you can actually book.</h1>
               <p className="ui-large text-pretty">Explore local ideas, save what you love, and connect with real NZ suppliers—all for free.</p>
             </div>
-            <div className="flex flex-col gap-sibling sm:flex-row">
+            <div className="tablet:flex-row flex flex-col gap-sibling">
               <Button size={'lg'} asChild>
                 <Link href="/sign-up" className="flex items-center gap-spouse">
                   <span>Sign up now</span>
@@ -67,10 +67,10 @@ export default function Home() {
               </Button>
             </div>
           </Area>
-          <Area className="relative col-span-1 overflow-hidden md:row-span-3">
+          <Area className="laptop:row-span-3 relative col-span-1 overflow-hidden">
             <Image className="object-cover" src="/assets/home-hero.jpg" alt="Couple, just married, celebrating with confetti" fill sizes="100vw" />
           </Area>
-          <Area className="relative col-span-2 row-span-1 overflow-hidden md:col-span-1">
+          <Area className="laptop:col-span-1 relative col-span-2 row-span-1 overflow-hidden">
             <Image className="object-cover" src="/assets/home-hero2.jpg" alt="Modern rustic place setting" fill sizes="100vw" />
           </Area>
         </div>
@@ -79,18 +79,18 @@ export default function Home() {
       <StackingCardsContainer cards={cards} />
 
       <Section>
-        <div className="grid gap-area md:grid-cols-3 md:grid-rows-1">
-          <Area className="relative min-h-[33svh] overflow-hidden md:col-span-1 md:row-span-full">
+        <div className="laptop:grid-cols-3 laptop:grid-rows-1 grid gap-area">
+          <Area className="laptop:col-span-1 laptop:row-span-full relative min-h-[33svh] overflow-hidden">
             <Image className="object-cover" src="/assets/home-supplier2.jpg" alt="Indian wedding couple exchanging garlands" fill sizes="33vw" />
           </Area>
-          <Area className="grid place-content-center gap-friend md:col-span-2 md:row-span-full">
+          <Area className="laptop:col-span-2 laptop:row-span-full grid place-content-center gap-friend">
             <div className="flex flex-col gap-sibling pr-xxl">
               <h2 className="heading-lg">Are you a wedding supplier?</h2>
               <p className="text-pretty">
                 Reach more couples, showcase your work, and get discovered on WeddingReady. It&apos;s free to join, and only takes a few minutes to set up.
               </p>
             </div>
-            <div className="flex flex-col gap-sibling sm:flex-row">
+            <div className="tablet:flex-row flex flex-col gap-sibling">
               <Button size="lg" asChild>
                 <Link href="/suppliers/join" className="flex items-center gap-spouse">
                   <span>Join as a supplier</span>

--- a/src/app/t/[tileId]/page.tsx
+++ b/src/app/t/[tileId]/page.tsx
@@ -28,7 +28,7 @@ export default async function TilePage({ params }: { params: Promise<{ tileId: s
 
   return (
     <Section className="min-h-svh-minus-header pt-0">
-      <div className="grid grid-cols-1 gap-area md:grid-cols-2">
+      <div className="laptop:grid-cols-2 grid grid-cols-1 gap-area">
         <Area className="relative overflow-clip rounded-area">
           <Image src={tile.imagePath} alt={tile.title ?? ''} fill sizes="(max-width: 768px) 100vw, 50vw" className="object-contain" />
           {authUserId && <SaveTileButton tileId={tile.id} authUserId={authUserId} className="absolute inset-0 flex items-start justify-end p-contour" />}

--- a/src/components/suppliers/suppliers-list.tsx
+++ b/src/components/suppliers/suppliers-list.tsx
@@ -2,9 +2,8 @@ import { Star } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
 
-
 export function SuppliersGrid({ children }: { children: React.ReactNode }) {
-  return <div className="grid grid-cols-1 gap-lg md:grid-cols-2 lg:grid-cols-3">{children}</div>
+  return <div className="wide:grid-cols-3 laptop:grid-cols-2 grid grid-cols-1 gap-lg">{children}</div>
 }
 
 type SupplierCardProps = {
@@ -19,7 +18,7 @@ type SupplierCardProps = {
 
 export function SupplierCard({ name, subtitle, mainImage, thumbnailImages, stat, href, avatar }: SupplierCardProps) {
   return (
-    <Link href={href} className="hover:shadow-contour grid gap-xs rounded transition-all hover:bg-primary/80 focus:bg-primary/80">
+    <Link href={href} className="grid gap-xs rounded transition-all hover:bg-primary/80 hover:shadow-contour focus:bg-primary/80">
       <div className="grid max-w-full grid-cols-3 grid-rows-2 gap-[1px] overflow-hidden rounded">
         <div className="relative col-span-2 row-span-2 aspect-square bg-white">
           <Image src={mainImage} alt={name} fill sizes="100vw" className="object-cover" />

--- a/src/components/tiles/tile-list.tsx
+++ b/src/components/tiles/tile-list.tsx
@@ -10,7 +10,7 @@ import { SaveTileButton } from './save-button'
 export function TileList({ tiles, authUserId }: { tiles: Tile[]; authUserId?: string }) {
   return (
     <>
-      <div className="grid grid-cols-2 gap-area md:grid-cols-3 lg:grid-cols-5">
+      <div className="wide:grid-cols-5 laptop:grid-cols-3 grid grid-cols-2 gap-area">
         {tiles.map((tile) => (
           <TileListItem key={tile.id} tile={tile} authUserId={authUserId} />
         ))}
@@ -38,7 +38,7 @@ export function TileListItem({ tile, authUserId }: { tile: Tile; authUserId?: st
 
 export function TileListSkeleton() {
   return (
-    <div className="grid grid-cols-2 gap-area md:grid-cols-3 lg:grid-cols-5">
+    <div className="wide:grid-cols-5 laptop:grid-cols-3 grid grid-cols-2 gap-area">
       {Array.from({ length: 5 }).map((_, index) => (
         <div key={index} className="grid grid-rows-[auto_1fr] gap-partner">
           <Skeleton className="aspect-[2/3] rounded-lg" />

--- a/src/components/ui/area.tsx
+++ b/src/components/ui/area.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/utils/shadcn-utils'
 
 export const Area = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ children, className, ...props }, ref) => {
   return (
-    <div ref={ref} className={cn('area px-md sm:px-area', className)} {...props}>
+    <div ref={ref} className={cn('area tablet:px-area px-md', className)} {...props}>
       {children}
     </div>
   )

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -7,7 +7,6 @@ import { X } from 'lucide-react'
 
 import { cn } from '@/utils/shadcn-utils'
 
-
 const Dialog = DialogPrimitive.Root
 
 const DialogTrigger = DialogPrimitive.Trigger
@@ -37,7 +36,7 @@ const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.C
       <DialogPrimitive.Content
         ref={ref}
         className={cn(
-          'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+          'tablet:rounded-lg fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
           className
         )}
         {...props}>
@@ -53,12 +52,12 @@ const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.C
 DialogContent.displayName = DialogPrimitive.Content.displayName
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+  <div className={cn('tablet:text-left flex flex-col space-y-1.5 text-center', className)} {...props} />
 )
 DialogHeader.displayName = 'DialogHeader'
 
 const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />
+  <div className={cn('tablet:flex-row tablet:justify-end tablet:space-x-2 flex flex-col-reverse', className)} {...props} />
 )
 DialogFooter.displayName = 'DialogFooter'
 

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,12 +2,11 @@ import * as React from 'react'
 
 import { cn } from '@/utils/shadcn-utils'
 
-
 const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<'textarea'>>(({ className, ...props }, ref) => {
   return (
     <textarea
       className={cn(
-        'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'laptop:text-sm flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
         className
       )}
       ref={ref}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,10 +7,10 @@ const config = {
   prefix: '',
   theme: {
     screens: {
-      sm: '450px',
-      md: '850px',
-      lg: '1550px',
-      xl: '2050px',
+      // mobile first. Breakpoint names apply to screen sizes larger than the pixel breakpoint value.
+      tablet: '450px',
+      laptop: '850px',
+      wide: '1550px',
     },
 
     extend: {


### PR DESCRIPTION
## Description

<!-- Provide a brief context and concise description of the changes made in this PR
Explain **what** this PR does and **why** it is needed.
Consider the audiences; reviewers, future developers, product managers, etc.
-->

This PR updates Tailwind CSS breakpoint names from the default responsive prefixes to more semantic, descriptive names that better reflect their intended use cases:

- `sm:` → `tablet:` (450px+)
- `md:` → `laptop:` (850px+) 
- `lg:` → `wide:` (1550px+)
- `xl:` removed (no longer needed)

**What changed:**
- Updated `tailwind.config.ts` to define new semantic breakpoint names
- Refactored all responsive classes across components and pages to use the new naming convention
- Updated documentation in `docs/patterns.md` to reflect the new breakpoint naming



## Testing

<!-- Describe unit tests added (if any) and testing performed -->

## Checklist

<!-- Mark completed items with 'x' -->

- [x] Code has been linted/formatted
- [x] Database migrations have been run
- [x] Documentation has been updated (if applicable)
- [x] Tests have been added/updated (if applicable)
- [x] All tests are passing

## Additional Context

<!-- Link related PR's and tickets -->
<!-- Add any additional information that reviewers should know -->
